### PR TITLE
Minor changes / fixes based RP data analysis

### DIFF
--- a/RP/ParseDiodeFiles.m
+++ b/RP/ParseDiodeFiles.m
@@ -23,7 +23,11 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
     for iSet=1:nDataSets
         fileName=strcat(files(iSet).folder,"\",files(iSet).name);
         fileID = fopen(fileName,"r");
-        C = textscan(fileID,"%{yyyy/MM:dd-HH:mm:ss}D CEST,%d");
+        try
+            C = textscan(fileID,"%{yyyy/MM:dd-HH:mm:ss}D CEST,%d"); % RP measurements till 18/10/2021 (included)
+        catch
+            C = textscan(fileID,"%{yyyy/MM/dd-HH:mm:ss}D CEST,%d"); % RP measurements after 19/10/2021 (included)
+        end
         fclose(fileID);
         nCounts=length(C{:,1});
         tStamps(nCountsTot+1:nCountsTot+nCounts)=C{1,1};

--- a/RP/ParseDiodeFiles.m
+++ b/RP/ParseDiodeFiles.m
@@ -26,6 +26,7 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
         try
             C = textscan(fileID,"%{yyyy/MM:dd-HH:mm:ss}D CEST,%d"); % RP measurements till 18/10/2021 (included)
         catch
+            frewind(fileID);
             C = textscan(fileID,"%{yyyy/MM/dd-HH:mm:ss}D CEST,%d"); % RP measurements after 19/10/2021 (included)
         end
         fclose(fileID);

--- a/RP/ParseStationaryFiles.m
+++ b/RP/ParseStationaryFiles.m
@@ -25,6 +25,7 @@ function [tStamps,doses,means,maxs,mins]=ParseStationaryFiles(path2Files,lCumul)
     fprintf("acquring %i data sets in %s ...\n",nDataSets,path2Files);
     nReadFiles=0;
     nCountsTot=0;
+    totDose=0.0;
     for iSet=1:nDataSets
         fileName=strcat(files(iSet).folder,"\",files(iSet).name);
         fileID = fopen(fileName,"r");
@@ -35,7 +36,8 @@ function [tStamps,doses,means,maxs,mins]=ParseStationaryFiles(path2Files,lCumul)
         means(nCountsTot+1:nCountsTot+nCounts)=C{:,3};
         maxs(nCountsTot+1:nCountsTot+nCounts)=C{:,4};
         mins(nCountsTot+1:nCountsTot+nCounts)=C{:,5};
-        doses(nCountsTot+1:nCountsTot+nCounts)=C{:,6};
+        doses(nCountsTot+1:nCountsTot+nCounts)=C{:,6}+totDose;
+        if ( lCumul ), totDose=doses(end); end
         nCountsTot=nCountsTot+nCounts;
         fprintf("...acquired %d entries in file %s...\n",nCounts,files(iSet).name);
         nReadFiles=nReadFiles+1;
@@ -55,7 +57,6 @@ function [tStamps,doses,means,maxs,mins]=ParseStationaryFiles(path2Files,lCumul)
             mins=mins(ids);
             maxs=maxs(ids);
         end
-        if ( lCumul ), doses=cumsum(doses); end % cumulative of all data 
     else
         tStamps=missing;
         doses=missing;


### PR DESCRIPTION
This PR provides some bug fixes / minor changes triggered by the analysis of RP data for the XPR:
* added possibility to crunch two formats of timestamps in diode log files;
* correct calculation of cumulative dose curve of multiple files by a single stationary monitor;