### PR TITLE
RP data analysis

### DIFF
--- a/RP/ParseDiodeFiles.m
+++ b/RP/ParseDiodeFiles.m
@@ -31,8 +31,24 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
         end
         fclose(fileID);
         nCounts=length(C{:,1});
-        tStamps(nCountsTot+1:nCountsTot+nCounts)=C{1,1};
-        counts(nCountsTot+1:nCountsTot+nCounts)=C{1,2};
+        ttStamps=C{1,1};
+        tCounts=C{1,2};
+        if ( nCountsTot==0 )
+            % first data set: simply acquire data
+            tStamps=ttStamps;
+            counts=tCounts;
+        else
+            % insert new data in proper position
+            [indCopy,iStart,iStop]=GetInsIndicesTimes(ttStamps,tStamps);
+            % - shift existing data
+            if ( iStart<nCountsTot )
+                tStamps(indCopy)=tStamps;
+                counts(indCopy)=counts;
+            end
+            % - insert new data
+            tStamps(iStart:iStop)=ttStamps;
+            counts(iStart:iStop)=tCounts;
+        end
         nCountsTot=nCountsTot+nCounts;
         fprintf("...acquired %d entries in file %s...\n",nCounts,files(iSet).name);
         nReadFiles=nReadFiles+1;

--- a/RP/ParsePolyMasterFiles.m
+++ b/RP/ParsePolyMasterFiles.m
@@ -25,9 +25,25 @@ function [tStamps,doses]=ParsePolyMasterFiles(path2Files)
         C = textscan(fileID,'%s %s %s %s %s %s %s %s','HeaderLines',1,'Delimiter',';');
         fclose(fileID);
         nCounts=length(C{:,1});
-        tStamps(nCountsTot+1:nCountsTot+nCounts)=datetime(join(string([C{:,1},C{:,2}])),"InputFormat","yyyy/MM/dd HH:mm:ss");
         temp=split(C{:,6});
-        doses(nCountsTot+1:nCountsTot+nCounts)=str2double(temp(:,1));
+        ttStamps=datetime(join(string([C{:,1},C{:,2}])),"InputFormat","yyyy/MM/dd HH:mm:ss");
+        tDoses=str2double(temp(:,1));
+        if ( nCountsTot==0 )
+            % first data set: simply acquire data
+            tStamps=ttStamps;
+            doses=tDoses;
+        else
+            % insert new data in proper position
+            [indCopy,iStart,iStop]=GetInsIndicesTimes(ttStamps,tStamps);
+            % - shift existing data
+            if ( iStart<nCountsTot )
+                tStamps(indCopy)=tStamps;
+                doses(indCopy)=doses;
+            end
+            % - insert new data
+            tStamps(iStart:iStop)=ttStamps;
+            doses(iStart:iStop)=tDoses;
+        end
         nCountsTot=nCountsTot+nCounts;
         fprintf("...acquired %d entries in file %s...\n",nCounts,files(iSet).name);
         nReadFiles=nReadFiles+1;

--- a/general/GetInsIndicesTimes.m
+++ b/general/GetInsIndicesTimes.m
@@ -1,0 +1,37 @@
+function [indCopy,iStart,iStop]=GetInsIndicesTimes(tStampsNew,tStampsExisting)
+% GetInsIndicesTimes         get insertion indices for a new time series
+%                                for insertion into an existing one
+%
+% input:
+% - tStampsNew (array of datetime): new series of timestamps;
+% - tStampsExisting (array of datetime): existing series of timestamps;
+% output:
+% - indCopy (array of indices): indices in the new array where the existing
+%   data should be copied;
+% - iStart,iStop (integers): starting and final indices in the new array
+%   where the new series should be inserted;
+%
+    indBef=find(tStampsExisting<=tStampsNew(1));
+    indAft=find(tStampsNew(end)<=tStampsExisting);
+    nExisting=length(tStampsExisting);
+    nInsert=length(tStampsNew);
+    if ( length(indBef)==nExisting && length(indAft)==0 )
+        % current data set should be appended
+        indCopy=indBef;
+        iStart=nExisting+1;
+        iStop=nExisting+nInsert;
+    elseif ( length(indBef)==0 && length(indAft)==nExisting )
+        % current data set should be headed
+        indCopy=indAft+nInsert;
+        iStart=1;
+        iStop=nInsert;
+    else
+        % current data set should be inserted
+        if ( indAft(1)-indBef(end)>1 )
+            error("...cannot insert acquired data set in time range already taken by other data");
+        end
+        indCopy=[ indBef ; indAft+nInsert ];
+        iStart=indBef(end)+1;
+        iStop=indBef(end)+nInsert;
+    end
+end

--- a/general/SortByTime.m
+++ b/general/SortByTime.m
@@ -24,15 +24,15 @@ function [tStampsOUT,countsOUT,ids]=SortByTime(tStampsIN,countsIN,nData)
     end
     if ( size(tStampsIN,2)==nMonitors ) 
         for iMonitor=1:nMonitors
-            [~,ids(:,iMonitor)]=sort(tStampsIN(1:nData(iMonitor),iMonitor));
-            tStampsOUT(1:nData(iMonitor),iMonitor)=tStampsIN(ids(:,iMonitor),iMonitor);
-            countsOUT(1:nData(iMonitor),iMonitor)=countsIN(ids(:,iMonitor),iMonitor);
+            [~,ids(1:nData(iMonitor),iMonitor)]=sort(tStampsIN(1:nData(iMonitor),iMonitor));
+            tStampsOUT(1:nData(iMonitor),iMonitor)=tStampsIN(ids(1:nData(iMonitor),iMonitor),iMonitor);
+            countsOUT(1:nData(iMonitor),iMonitor)=countsIN(ids(1:nData(iMonitor),iMonitor),iMonitor);
         end
     else
-        [tStampsOUT(:),idx]=sort(tStampsIN(:));
+        [tStampsOUT,idx]=sort(tStampsIN(:));
         for iMonitor=1:nMonitors
-            ids(:,iMonitor)=idx(:);
-            countsOUT(1:nData(iMonitor),iMonitor)=countsIN(ids(:,iMonitor),iMonitor);
+            ids(1:nData(iMonitor),iMonitor)=idx(:);
+            countsOUT(1:nData(iMonitor),iMonitor)=countsIN(ids(1:nData(iMonitor),iMonitor),iMonitor);
         end
     end
     fprintf("...done;\n");

--- a/measurement_analysis/StatDistributions.m
+++ b/measurement_analysis/StatDistributions.m
@@ -1,4 +1,4 @@
-function [BARs,FWxMs,INTs]=StatDistributions(profiles,FWxMval,noiseLevelFWxM,INTlevel,lDebug)
+function [BARs,FWxMs,INTs]=StatDistributions(profiles,FWxMval,noiseLevelFWxM,INTlevel,lDebug,dTitle)
 % StatDistributions                  to compute basic statistical infos of
 %                                       distributions (acquired by both DDS and CAMeretta);
 % The algorithm is based on the one for CAMeretta, but it is centred around
@@ -10,13 +10,14 @@ function [BARs,FWxMs,INTs]=StatDistributions(profiles,FWxMval,noiseLevelFWxM,INT
 %   . rows: index of independent coordinate (e.g. time/position);
 %   . columns: index of the signal to process;
 %   NB: column 1 is the list of values of the independent variable;
-% - FWxMval (array): values (ratios to max) at which the FW should be computed
+% - FWxMval (1D array,optional): values (ratios to max) at which the FW should be computed
 %     (either as percentage or as ratio to 1); default (scalar): 50% (FWHM);
-% - noiseLevelFWxM (scalar): cut threshold for computing FWxM
+% - noiseLevelFWxM (scalar,optional): cut threshold for computing FWxM
 %     (either as percentage or as ratio to 1); default: 20%;
-% - INTlevel (scalar): min value of integral above which a profile should be
+% - INTlevel (scalar,optional): min value of integral above which a profile should be
 %     considered for analisis; default: 20k;
-% - lDebug (boolean): activate debug mode (for the time being, plots);
+% - lDebug (boolean,optional): activate debug mode (for the time being, plots);
+% - dTitle (string,optional): title to be displayed in debug plots;
 %
 % output:
 % - BARs (2D float array): max of smoothed distribution;
@@ -39,6 +40,7 @@ function [BARs,FWxMs,INTs]=StatDistributions(profiles,FWxMval,noiseLevelFWxM,INT
     if ( ~exist('noiseLevelFWxM','var') ), noiseLevelFWxM=0.18; end
     if ( ~exist('INTlevel','var') ), INTlevel=20000; end
     if ( ~exist('lDebug','var') ), lDebug=true; end
+    if ( ~exist('dTitle','var') ), dTitle=""; end
     
     fprintf("computing INTs, BARs and FWxMs...\n");
     % if >1, levels are assumed in percentage
@@ -107,10 +109,15 @@ function [BARs,FWxMs,INTs]=StatDistributions(profiles,FWxMval,noiseLevelFWxM,INT
                      myXs,myYs,"*",myXs,repYs,".-", ...                             % filtered signal and interpolated signal
                      [FWxMleft ; FWxMright],[FWxMvalAbs ; FWxMvalAbs],"k-",...      % FWxM
                      [BARs(iSet,iPlane) BARs(iSet,iPlane)], [0.0 1.1*tmpMax],"k-"); % BAR
-                title(sprintf("%s plane",planes(iPlane))); grid on; xlabel("fiber position [mm]"); ylabel("counts []");
+                grid on; xlabel("fiber position [mm]"); ylabel("counts []");
+                if ( strlength(dTitle)>0 )
+                    title(sprintf("%s plane - %s",planes(iPlane)),dTitle);
+                else
+                    title(sprintf("%s plane",planes(iPlane)));
+                end
             end
         end
-        if ( lDebug ), pause(0.1); end
+        if ( lDebug ), pause(0.01); end
     end
     fprintf("...done.\n");
 end

--- a/operations/cyCodes/ConvertCyCodes.m
+++ b/operations/cyCodes/ConvertCyCodes.m
@@ -30,18 +30,18 @@ function vOut=ConvertCyCodes(cyCodesIN,what,pathP,pathC)
     % verify that all particle codes are recognizable
     unidentified=(partCodes<0 & partCodes>3 );
     if ( sum(unidentified)>0 )
-        error("unidentified particle in some cyCodes:\n%s",join(cyCodesIN(unidentified),newline));
+        warning("unidentified particle in some cyCodes:\n%s",join(cyCodesIN(unidentified),newline));
     end
     [lCCP,iCCP]=MapCyCode(rangeCodes,P_cyCodes);
     [lCCC,iCCC]=MapCyCode(rangeCodes,C_cyCodes);
     % verify that all ranges are recognizable
     unidentified=find(~lCCC & ~lCCP);
     if ( sum(unidentified)>0 )
-        error("unidentified range in some cyCodes:\n%s",join(cyCodesIN(unidentified),newline));
+        warning("unidentified range in some cyCodes:\n%s",join(cyCodesIN(unidentified),newline));
     end
     
     % assign values
-    vOut=zeros(length(cyCodesIN),1);
+    vOut=NaN(length(cyCodesIN),1);
     indices_P=(lCCP & FlagPart(partCodes,"p") );
     indices_C=(lCCC & FlagPart(partCodes,"C") );
     switch upper(what)


### PR DESCRIPTION
A series of (minor) changes and bug fixes:
* bug fix in parsing log files of stationary monitors. The bug was two-folded:
   * when sorting parsed data by time stamp, the last value read from a file was after the first value of the following one;
   * when computing cumulative doses, the cumulative dose was computed in order of parsing, not in (actual) order of time.
* function for computing statistics on acquired profiles shows (in debug mode) plots with a more sensible title + warnings (instead of errors) thrown at unidentified cycodes.