### PR TITLE
RP data analysis updates

### DIFF
--- a/RP/ParseDiodeFiles.m
+++ b/RP/ParseDiodeFiles.m
@@ -1,9 +1,13 @@
-function [tStamps,counts]=ParseDiodeFiles(path2Files)
+function [tStamps,counts]=ParseDiodeFiles(path2Files,lCollapse)
 % ParseDiodeFiles         acquire data in log files of diodes (REM counters)
 %
 % input:
 % - path2Files: path where the file(s) is located (a dir command is anyway performed).
 %               All data files are associated to a single monitor.
+% - lCollapse: boolean, triggering the collapsing of parsed data to
+%               available timestamps. This functionality can be useful
+%               whenever the data set has more than a count per time
+%               division, such that the number of entries can be reduced.
 % output:
 % - tStamps (array of time stamps): time stamps of counts;
 % - counts (array of floats): counts at each time stamp;
@@ -15,6 +19,7 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
 %
 % See also ParseStationaryFiles and ParsePolyMasterFiles.
 
+    if ( ~exist('lCollapse','var') ), lCollapse=false; end
     files=dir(path2Files);
     nDataSets=length(files);
     fprintf("acquring %i data sets in %s ...\n",nDataSets,path2Files);
@@ -30,9 +35,9 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
             C = textscan(fileID,"%{yyyy/MM/dd-HH:mm:ss}D CEST,%d"); % RP measurements after 19/10/2021 (included)
         end
         fclose(fileID);
-        nCounts=length(C{:,1});
-        ttStamps=C{1,1};
-        tCounts=C{1,2};
+        nCounts=min(length(C{:,1}),length(C{:,2})); % try to catch the case where there are empty lines at the end, not correctly parsed
+        ttStamps=C{1,1}; ttStamps=ttStamps(1:nCounts);
+        tCounts=C{1,2}; tCounts=tCounts(1:nCounts);
         if ( nCountsTot==0 )
             % first data set: simply acquire data
             tStamps=ttStamps;
@@ -61,6 +66,28 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files)
         end
         if ( nDataSets>1 )
             [tStamps,counts,~]=SortByTime(tStamps,counts); % sort by timestamps
+        end
+        if ( lCollapse )
+            oldLength=length(tStamps);
+            GC=[]; GR=[];
+            % keep original structure of resets
+            iOnes=find(counts==1);
+            for iOne=1:length(iOnes)
+                if ( iOne==length(iOnes) )
+                    % last segment
+                    [tmpGC,tmpGR]=groupcounts(tStamps(iOnes(end):end));
+                elseif ( iOne==1 & iOnes(iOne)>1 )
+                    % before first segment
+                    [tmpGC,tmpGR]=groupcounts(tStamps(1:iOnes(iOne)-1));
+                else
+                    [tmpGC,tmpGR]=groupcounts(tStamps(iOnes(iOne):iOnes(iOne+1)-1));
+                end
+                GC=[GC cumsum(tmpGC)']; GR=[GR tmpGR'];
+            end
+            clear counts tStamps;
+            counts=GC'; tStamps=GR';
+            newLength=length(tStamps);
+            warning("...collapsed raw data: from %d entries to %d entries;",oldLength,newLength);
         end
     else
         tStamps=missing;

--- a/RP/ParseDiodeFiles.m
+++ b/RP/ParseDiodeFiles.m
@@ -19,7 +19,7 @@ function [tStamps,counts]=ParseDiodeFiles(path2Files,lCollapse)
 %
 % See also ParseStationaryFiles and ParsePolyMasterFiles.
 
-    if ( ~exist('lCollapse','var') ), lCollapse=false; end
+    if ( ~exist('lCollapse','var') ), lCollapse=true; end
     files=dir(path2Files);
     nDataSets=length(files);
     fprintf("acquring %i data sets in %s ...\n",nDataSets,path2Files);

--- a/general/GetIncrementalName.m
+++ b/general/GetIncrementalName.m
@@ -1,0 +1,20 @@
+function newName=GetIncrementalName(origName,lDebug)
+    if ( ~exist('lDebug','var') ), lDebug=false; end
+    if ( isfile(origName) )
+        origNameSplit=split(origName,".");
+        ext=origNameSplit(end);
+        lE=strlength(ext); lS=strlength(origName);
+        for ii=2:99
+            newName=sprintf("%s_%02d.%s",extractBetween(origName,1,lS-lE-1),ii,ext);
+            if ( ~isfile(newName) )
+                if ( lDebug )
+                    warning("GetIncrementalName: OLD name: %s; NEW name: %s",origName,newName);
+                end
+                break;
+            end
+        end
+    else
+        newName=origName;
+    end
+    
+end


### PR DESCRIPTION
This PR provides a minor set of code updates needed by crunching RP data taking for the XPR of 6-7 April 2022 - see PR https://github.com/amereghe/RPdataAnalysis/pull/29

It comes with:
* a flag in the function parsing diode log files which collapses all counts happing in a single time stamp to that time stamp. This allows to decrease the number of entries stored in memory, in particular for those diodes with very high count rates (e.g. that substituting the stationary monitor in the XPR). By default, the flag is false (no collapsing is performed);
* a general function which appends a counter to the name of a file already present on disk that otherwise would be overwritten.