### PR TITLE
Parse CAMeretta dumps and plotting stuff

### DIFF
--- a/CreateQAfiles.m
+++ b/CreateQAfiles.m
@@ -10,8 +10,10 @@
 
 %% include libraries
 % - include Matlab libraries
-pathToLibrary=".\";
-addpath(genpath(pathToLibrary));
+if (~exist("pathToLibrary","var"))
+    pathToLibrary=".\";
+    addpath(genpath(pathToLibrary));
+end
 
 %% settings
 

--- a/DisplayBeamProfiles.m
+++ b/DisplayBeamProfiles.m
@@ -24,8 +24,8 @@ if (~exist("MonPaths","var"))
     % default stuff
     % -------------------------------------------------------------------------
     % - include Matlab libraries
-    pathToLibrary=".\";
-    addpath(genpath(pathToLibrary));
+%     pathToLibrary=".\";
+%     addpath(genpath(pathToLibrary));
     % - clear settings
     clear kPath myTit monTypes MonPaths myLabels
 
@@ -33,27 +33,43 @@ if (~exist("MonPaths","var"))
     % USER's input data
     % -------------------------------------------------------------------------
     kPath="P:\Accelerating-System\Accelerator-data";
-    monTypes=[ "GIM" ]; % CAM, DDS, GIM, QPP/SFH/SFM/SFP - QBM/PMM/PIB to come
+    monTypes="CAMdumps"; % CAM/CAMdumps, DDS, GIM, QBM/QPP/PIB/PMM/SFH/SFM/SFP
     myLabels=[...
-        "H2-009B-GIM"
+        "test 1: H scan (1E6 per spot)"
+        "test 2: grid (1E6 per spot)"
+        "test 3: V scan (1E6 per spot)"
+        "test 4: V scan (1.2E6 per spot)"
+        "test 5: V scan (1.2E6 per spot)"
+        "test 6: H scan (1.2E6 per spot)"
+        "test 7: H scan (1.2E6 per spot)"
+        "test 8: grid (1.2E6 per spot)"
         ];
-    myLabels=monTypes;
+    % myLabels=monTypes;
     lSkip=false; % DDS summary file: skip first 2 lines (in addition to header line)
     myFigPath=".";
     % part-dependent stuff
     % - protoni
-%     myFigName="summary_protoni_GIM_2023-05-09.10";
-%     myTit="summary 2023-05-09.10 - Protoni";
-%     MonPaths=[...
-%         strcat(kPath,"\Area dati MD\00Summary\Protoni\2023\Maggio\2023.05.09-10\Steering ridotti\GIM\PRC-544-230511-0147_H2-009B-GIM_AllTrig\") 
-%         ];
-    % - carbonio
-    myFigName="summary_carbonio_GIM_2023-05-09.10";
-    myTit="summary 2023-05-09.10 - Carbonio";
+    myFigName="Tests with DDS";
+    myTit="Tests with DDS";
     MonPaths=[...
-        strcat(kPath,"\Area dati MD\00Summary\Carbonio\2023\Maggio\2023.05.09-10\Steering ridotti\GIM\PRC-544-230511-0028_H2-009B-GIM_AllTrig\") 
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2213\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2219\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2222\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2225\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2227\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2229\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2231\"
+        "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2233\"
         ];
-    vsX="EK"; % ["Ek"/"En"/"Energy","mm"/"r"/"range","ID"/"IDs"]
+%     % - carbonio
+%     myFigName="summary_carbonio_GIM_2023-05-09.10";
+%     myTit="summary 2023-05-09.10 - Carbonio";
+%     MonPaths=[...
+%         strcat(kPath,"\Area dati MD\00Summary\Carbonio\2023\Maggio\2023.05.09-10\Steering ridotti\GIM\PRC-544-230511-0028_H2-009B-GIM_AllTrig\") 
+%         ];
+    vsX="ID"; % ["Ek"/"En"/"Energy","mm"/"r"/"range","ID"/"IDs"]
+    iNotShow=false(127,2);
+    iNotShow(1:2,1)=true; % do not show left-most fibers on hor plane (broken)
 end
 
 %% check of user input data
@@ -72,6 +88,7 @@ if (length(monTypes)~=nDataSets)
     end
 end
 if (~exist("vsX","var")), vsX="mm"; end
+if (~exist("iNotShow","var")), iNotShow=NaN(1,2); end
 
 %% clear storage
 % - clear summary data
@@ -85,19 +102,30 @@ if (~exist("vsX","var")), vsX="mm"; end
 for iDataAcq=1:nDataSets
     % - parse profiles
     clear tmpCyProgsProf tmpCyCodesProf tmpBARsProf tmpFWHMsProf tmpINTsProf tmpProfiles tmpDiffProfiles tmpEksProf tmpMmsProf;
-    if ( strcmpi(monTypes(iDataAcq),"CAM") | strcmpi(monTypes(iDataAcq),"DDS") )
-        [tmpProfiles,tmpCyCodesProf,tmpCyProgsProf]=ParseBeamProfiles(MonPaths(iDataAcq),monTypes(iDataAcq));
-        if (length(tmpCyProgsProf)<=1), error("...no profiles aquired!"); end
-    else % GIM,QPP,SFH,SFM,SFP
-        [tmpDiffProfiles,tmpCyCodesProf,tmpCyProgsProf]=ParseBeamProfiles(MonPaths(iDataAcq),monTypes(iDataAcq));
-        if (length(tmpCyProgsProf)<=1), error("...no profiles aquired!"); end
-        % - get integral profiles
-        tmpProfiles=SumSpectra(tmpDiffProfiles); 
+    switch upper(monTypes(iDataAcq))
+        case {"CAM","DDS"}
+            [tmpProfiles,tmpCyCodesProf,tmpCyProgsProf]=ParseBeamProfiles(MonPaths(iDataAcq),monTypes(iDataAcq));
+            if (length(tmpCyProgsProf)<=1), error("...no profiles aquired!"); end
+        otherwise % CAMdumps and BD: GIM, QBM/QPP/PIB/PMM/SFH/SFM/SFP
+            [tmpDiffProfiles,tmpCyCodesProf,tmpCyProgsProf]=ParseBeamProfiles(MonPaths(iDataAcq),monTypes(iDataAcq));
+            if (length(tmpCyProgsProf)<=1), error("...no profiles aquired!"); end
+            % - get integral profiles
+            tmpProfiles=SumSpectra(tmpDiffProfiles); 
     end
     % - get statistics out of profiles
     switch upper(monTypes(iDataAcq))
         case "CAM"
             [tmpBARsProf,tmpFWHMsProf,tmpINTsProf]=StatDistributionsCAMProcedure(tmpProfiles);
+        case "CAMDUMPS"
+%             FWHMval=0.5;
+%             noiseLevelBAR=0.0; noiseLevelFWHM=0.0;
+%             INTlevel=0.0;
+%             lDebug=true;
+%             [tmpBARsProf,tmpFWHMsProf,tmpINTsProf]=StatDistributionsCAMProcedure(tmpProfiles,FWHMval,noiseLevelBAR,noiseLevelFWHM,INTlevel,lDebug);
+            noiseLevel=0.0;
+            INTlevel=0;
+            lDebug=true;
+            [tmpBARsProf,tmpFWHMsProf,tmpINTsProf]=StatDistributionsBDProcedure(tmpProfiles,noiseLevel,INTlevel,lDebug);
         case {"QPP","SFP"}
             noiseLevel=0.025;
             INTlevel=5;
@@ -163,11 +191,11 @@ if (exist("shifts","var"))
 end
 % - 3D plot of profiles
 if (exist("myFigPath","var")), myFigSave=strcat(myFigPath,"\3Dprofiles_",myFigName,".fig"); else myFigSave=missing(); end
-ShowSpectra(profiles,sprintf("%s - 3D profiles",myTit),addIndex,addLabel,myLabels,myFigSave);
-% - statistics on profiles
+ShowSpectra(profiles,sprintf("%s - 3D profiles",myTit),addIndex,addLabel,myLabels,myFigSave,1,iNotShow); % use 3D sinogram style
+% - show statistics on profiles
 if (exist("myFigPath","var")), myFigSave=strcat(myFigPath,"\Stats_",myFigName,".fig"); else myFigSave=missing(); end
 ShowBeamProfilesSummaryData(BARsProf,FWHMsProf,INTsProf,missing(),addIndex,addLabel,myLabels,missing(),myTit,myFigSave);
-% - statistics on profiles vs summary files
+% - show statistics on profiles vs summary files
 iDataSumm=0;
 for iDataAcq=1:nDataSets
     switch upper(monTypes(iDataAcq))

--- a/DisplayBeamProfiles.m
+++ b/DisplayBeamProfiles.m
@@ -24,8 +24,8 @@ if (~exist("MonPaths","var"))
     % default stuff
     % -------------------------------------------------------------------------
     % - include Matlab libraries
-%     pathToLibrary=".\";
-%     addpath(genpath(pathToLibrary));
+    pathToLibrary=".\";
+    addpath(genpath(pathToLibrary));
     % - clear settings
     clear kPath myTit monTypes MonPaths myLabels
 
@@ -68,8 +68,8 @@ if (~exist("MonPaths","var"))
 %         strcat(kPath,"\Area dati MD\00Summary\Carbonio\2023\Maggio\2023.05.09-10\Steering ridotti\GIM\PRC-544-230511-0028_H2-009B-GIM_AllTrig\") 
 %         ];
     vsX="ID"; % ["Ek"/"En"/"Energy","mm"/"r"/"range","ID"/"IDs"]
-    iNotShow=false(127,2);
-    iNotShow(1:2,1)=true; % do not show left-most fibers on hor plane (broken)
+    iNotShow=false(127,2); 
+    iNotShow(1:2,1)=true;  % do not show left-most fibers on hor plane (broken)
 end
 
 %% check of user input data

--- a/DisplayBeamProfiles.m
+++ b/DisplayBeamProfiles.m
@@ -24,8 +24,10 @@ if (~exist("MonPaths","var"))
     % default stuff
     % -------------------------------------------------------------------------
     % - include Matlab libraries
-    pathToLibrary=".\";
-    addpath(genpath(pathToLibrary));
+    if (~exist("pathToLibrary","var"))
+        pathToLibrary=".\";
+        addpath(genpath(pathToLibrary));
+    end
     % - clear settings
     clear kPath myTit monTypes MonPaths myLabels
 

--- a/DisplayBeamProfilesWithTime.m
+++ b/DisplayBeamProfilesWithTime.m
@@ -19,6 +19,8 @@
 % - include Matlab libraries
 % pathToLibrary=".\";
 % addpath(genpath(pathToLibrary));
+clear all;
+close all;
 
 %% USER's input data
 % -------------------------------------------------------------------------
@@ -34,9 +36,17 @@ monTypes="CAMdumps";
 % skip fibers/channels?
 iNotCons=false(127,2); 
 iNotCons(1:2,1)=true;  % do not consider left-most fibers on hor plane (broken)
+lConcatenate=true;
+
+%% check USER's input data
+% -------------------------------------------------------------------------
+if (~exist("lConcatenate","var")), lConcatenate=false; end
+if (~exist("iNotCons","var")), iNotCons=NaN(1,2); end
 
 %% acquire profiles
 [tmpDiffProfiles,tmpCyCodesProf,tmpCyProgsProf,tmpTimes]=ParseBeamProfiles(MonPaths,monTypes);
+% tmpTimes=BeamProfilesAlignTimes(tmpTimes); % align time frames
+[tmpDiffProfiles,tmpTimes]=BeamProfilesConcatenateTimes(tmpDiffProfiles,tmpTimes); % concatenate profiles
 
 %% set to 0.0 channels to be ignored and get integrals
 profsToCrunch=tmpDiffProfiles;

--- a/DisplayBeamProfilesWithTime.m
+++ b/DisplayBeamProfilesWithTime.m
@@ -1,0 +1,66 @@
+% {}~
+
+%% description
+% this is a script which parses beam profiles files with time and plots them
+%     as 2D histograms (profiles vs time), giving also 1D histograms
+%     showing:
+%     - sum distributions;
+%     - evolution with time of integral;
+%
+% NOTA BENE: given the large amount of data, the script can crunch (for the
+%            time being) only a single series of extractions;
+%
+% TO-DO LIST:
+% - concatenate as many paths as desired;
+% - save figures;
+
+%% default stuff
+% -------------------------------------------------------------------------
+% - include Matlab libraries
+% pathToLibrary=".\";
+% addpath(genpath(pathToLibrary));
+
+%% USER's input data
+% -------------------------------------------------------------------------
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2213\";
+MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2219\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2222\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2225\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2227\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2229\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2231\";
+% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2233\";
+monTypes="CAMdumps";
+% skip fibers/channels?
+iNotCons=false(127,2); 
+iNotCons(1:2,1)=true;  % do not consider left-most fibers on hor plane (broken)
+
+%% acquire profiles
+[tmpDiffProfiles,tmpCyCodesProf,tmpCyProgsProf,tmpTimes]=ParseBeamProfiles(MonPaths,monTypes);
+
+%% set to 0.0 channels to be ignored and get integrals
+profsToCrunch=tmpDiffProfiles;
+if (exist("iNotCons","var"))
+    for iPlane=1:2
+        profsToCrunch(iNotCons(:,iPlane),2:end,iPlane,:)=0.0;
+    end
+end
+integratedProfiles=SumSpectra(profsToCrunch); 
+intensityEvolutions=SumSpectra(profsToCrunch,tmpTimes); 
+
+%% show stuff
+nExtr=size(profsToCrunch,4);
+myConts=missing(); lHist=true; lSquared=false; lBinEdges=false;
+yLab="t [ms]";
+planes=["HOR" "VER"];
+xLabs=[ "x [mm]" "y [mm]" ];
+ffs=[ figure() figure() ];
+for iExtr=1:nExtr
+    pause();
+    for iPlane=1:2
+        set(0, 'currentfigure', ffs(iPlane));  %# for figures
+        Plot2DHistograms(profsToCrunch(:,2:end,iPlane,iExtr),integratedProfiles(:,1+iExtr,iPlane),intensityEvolutions(:,1+iExtr,iPlane),...
+            integratedProfiles(:,1,iPlane)',intensityEvolutions(:,1,iPlane)',xLabs(iPlane),yLab,myConts,lHist,lSquared,lBinEdges);
+        sgtitle(sprintf("plane: %s - cyProg: %s - cyCode: %s",planes(iPlane),tmpCyProgsProf(iExtr),tmpCyCodesProf(iExtr)));
+    end
+end

--- a/DisplayBeamProfilesWithTime.m
+++ b/DisplayBeamProfilesWithTime.m
@@ -1,76 +1,185 @@
 % {}~
 
 %% description
-% this is a script which parses beam profiles files with time and plots them
-%     as 2D histograms (profiles vs time), giving also 1D histograms
-%     showing:
-%     - sum distributions;
-%     - evolution with time of integral;
+% this is a script which parses files with beam iles vs time and plots them
+%   as 2D histograms (iles vs time), giving also 1D histograms showing:
+%   - sum distributions;
+%   - evolution with time of integral;
+% A single figure is shown per plane; for every extraction, new figures are
+%   generated. A summary plot, showing the evolution of stats with time, is
+%   shown as well.
 %
 % NOTA BENE: given the large amount of data, the script can crunch (for the
 %            time being) only a single series of extractions;
 %
-% TO-DO LIST:
-% - concatenate as many paths as desired;
-% - save figures;
 
 %% default stuff
 % -------------------------------------------------------------------------
 % - include Matlab libraries
-% pathToLibrary=".\";
-% addpath(genpath(pathToLibrary));
+pathToLibrary=".\";
+addpath(genpath(pathToLibrary));
+% - some clean up
 clear all;
 close all;
 
 %% USER's input data
 % -------------------------------------------------------------------------
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2213\";
-MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2219\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2222\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2225\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2227\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2229\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2231\";
-% MonPaths="P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2233\";
+MonPaths=[
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2213\"
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2219\"
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2222\";
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2225\";
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2227\";
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2229\";
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2231\";
+    "P:\Accelerating-System\Accelerator-data\scambio\Alessio\2023-08-21_testsOcchiConiglio\DumpProtSO1_LineT_Size10_22-08-2023_2233\";
+];
 monTypes="CAMdumps";
+myLabels=[
+    "test 1: H scan (1E6 per spot)"
+    "test 2: grid (1E6 per spot)"
+    "test 3: V scan (1E6 per spot)"
+    "test 4: V scan (1.2E6 per spot)"
+    "test 5: V scan (1.2E6 per spot)"
+    "test 6: H scan (1.2E6 per spot)"
+    "test 7: H scan (1.2E6 per spot)"
+    "test 8: grid (1.2E6 per spot)"
+];
+myFigPath=".";
+myFigName="TestsWithDDS";
+myTit="Tests with DDS";
+
 % skip fibers/channels?
 iNotCons=false(127,2); 
 iNotCons(1:2,1)=true;  % do not consider left-most fibers on hor plane (broken)
-lConcatenate=true;
+lConcatenate=true;     % concatenate all extractions as if only a long one took place
+lSuperImposeStats=false;
 
 %% check USER's input data
 % -------------------------------------------------------------------------
-if (~exist("lConcatenate","var")), lConcatenate=false; end
-if (~exist("iNotCons","var")), iNotCons=NaN(1,2); end
-
-%% acquire profiles
-[tmpDiffProfiles,tmpCyCodesProf,tmpCyProgsProf,tmpTimes]=ParseBeamProfiles(MonPaths,monTypes);
-% tmpTimes=BeamProfilesAlignTimes(tmpTimes); % align time frames
-[tmpDiffProfiles,tmpTimes]=BeamProfilesConcatenateTimes(tmpDiffProfiles,tmpTimes); % concatenate profiles
-
-%% set to 0.0 channels to be ignored and get integrals
-profsToCrunch=tmpDiffProfiles;
-if (exist("iNotCons","var"))
-    for iPlane=1:2
-        profsToCrunch(iNotCons(:,iPlane),2:end,iPlane,:)=0.0;
+if ( length(MonPaths)~=length(myLabels) )
+    error("number of paths different from number of labels: %d~=%d",length(MonPaths),length(myLabels));
+else
+    nDataSets=length(MonPaths);
+end
+if (length(monTypes)~=nDataSets)
+    if ( length(monTypes)==1 )
+        myStrings=strings(nDataSets,1);
+        myStrings(:,1)=monTypes;
+        monTypes=myStrings;
+    else
+        error("please specify a label for each data set");
     end
 end
-integratedProfiles=SumSpectra(profsToCrunch); 
-intensityEvolutions=SumSpectra(profsToCrunch,tmpTimes); 
+if (~exist("lConcatenate","var")), lConcatenate=false; end
+if (~exist("iNotCons","var")), iNotCons=NaN(1,2); end
+if (~exist("lSuperImposeStats","var")), lSuperImposeStats=false; end
 
-%% show stuff
-nExtr=size(profsToCrunch,4);
+%% set up running vars
+% - plotting style:
 myConts=missing(); lHist=true; lSquared=false; lBinEdges=false;
 yLab="t [ms]";
 planes=["HOR" "VER"];
 xLabs=[ "x [mm]" "y [mm]" ];
-ffs=[ figure() figure() ];
-for iExtr=1:nExtr
-    pause();
-    for iPlane=1:2
-        set(0, 'currentfigure', ffs(iPlane));  %# for figures
-        Plot2DHistograms(profsToCrunch(:,2:end,iPlane,iExtr),integratedProfiles(:,1+iExtr,iPlane),intensityEvolutions(:,1+iExtr,iPlane),...
-            integratedProfiles(:,1,iPlane)',intensityEvolutions(:,1,iPlane)',xLabs(iPlane),yLab,myConts,lHist,lSquared,lBinEdges);
-        sgtitle(sprintf("plane: %s - cyProg: %s - cyCode: %s",planes(iPlane),tmpCyProgsProf(iExtr),tmpCyCodesProf(iExtr)));
+FWHM2sig=2*sqrt(2*log(2));
+
+%% crunch stuff
+for iDataAcq=1:nDataSets
+
+    % for saving figures
+    figNameCase=myLabels(iDataAcq);
+    figNameCase=strrep(figNameCase," ","");
+    figNameCase=strrep(figNameCase,":","-");
+    
+    %% parse profiles
+    clear tmpDiffiles tmpCyProgs tmpCyCodes tmpTimes ProfsToCrunch;
+    [tmpProfiles,tmpCyCodes,tmpCyProgs,tmpTimes]=ParseBeamProfiles(MonPaths(iDataAcq),monTypes(iDataAcq));
+    if (lConcatenate)
+        % concatenate all extractions, as if there was only a very long one
+        [tmpProfiles,tmpTimes]=BeamProfilesConcatenateTimes(tmpProfiles,tmpTimes);
+    else
+        % align time frames, such that all extractions have the same time
+        %   framework
+        tmpTimes=BeamProfilesAlignTimes(tmpTimes);
     end
+    
+    %% post-processing
+    % - cleaning: set to 0.0 channels to be ignored and get integrals
+    ProfsToCrunch=tmpProfiles;
+    if (exist("iNotCons","var"))
+        for iPlane=1:2
+            ProfsToCrunch(iNotCons(:,iPlane),2:end,iPlane,:)=0.0;
+        end
+    end
+    % - Eks,mms
+    tmpEksProf=ConvertCyCodes(tmpCyCodes,"Ek","MeVvsCyCo_P.xlsx");
+    tmpMmsProf=ConvertCyCodes(tmpCyCodes,"mm","MeVvsCyCo_P.xlsx");
+    % - integrals
+    integratedProfiles=SumSpectra(ProfsToCrunch); 
+    intensityEvolutions=SumSpectra(ProfsToCrunch,tmpTimes); 
+    % - some cleaning:
+    [BARsProf,FWHMsProf,INTsProf]=deal(missing(),missing(),missing());
+
+    %% plotting
+    nExtr=size(ProfsToCrunch,4);
+    ffs=[ figure() figure() ];
+    statLabels=strings(nExtr,1);
+    for iExtr=1:nExtr
+        pause();
+        % - statistics
+        noiseLevel=0.0;
+        INTlevel=0;
+        [tmpBARsProf,tmpFWHMsProf,tmpINTsProf]=StatDistributionsBDProcedure(ProfsToCrunch(:,:,:,iExtr),noiseLevel,INTlevel);
+        BARsProf=ExpandMat(BARsProf,tmpBARsProf);
+        FWHMsProf=ExpandMat(FWHMsProf,tmpFWHMsProf);
+        INTsProf=ExpandMat(INTsProf,tmpINTsProf);
+        % - actually plot
+        for iPlane=1:2
+            set(0, 'currentfigure', ffs(iPlane));  % for figures
+            % - contours, i.e. BARs and SIGs
+            if (lSuperImposeStats)
+                myConts=zeros(size(tmpBARsProf,1),2,3);
+                myConts(:,1,1)=tmpBARsProf(:,iPlane); myConts(:,2,1)=tmpTimes(:,1);  % BARs
+                myConts(:,1,2)=tmpBARsProf(:,iPlane)+tmpFWHMsProf(:,iPlane)/FWHM2sig; myConts(:,2,2)=tmpTimes(:,1);  % BARs+1sig
+                myConts(:,1,3)=tmpBARsProf(:,iPlane)-tmpFWHMsProf(:,iPlane)/FWHM2sig; myConts(:,2,3)=tmpTimes(:,1);  % BARs-1sig
+            end
+            Plot2DHistograms(ProfsToCrunch(:,2:end,iPlane,iExtr),integratedProfiles(:,1+iExtr,iPlane),intensityEvolutions(:,1+iExtr,iPlane),...
+                integratedProfiles(:,1,iPlane)',intensityEvolutions(:,1,iPlane)',xLabs(iPlane),yLab,myConts,lHist,lSquared,lBinEdges);
+            if (lConcatenate)
+                sgtitle(sprintf("plane: %s - %s - %s \n cyProgs: [%s:%s] - cyCodes: [%s:%s]",...
+                    planes(iPlane),myLabels(iDataAcq),myTit,tmpCyProgs(1),tmpCyProgs(end),tmpCyCodes(1),tmpCyCodes(end)));
+                myFigSave=strcat(myFigPath,"/",myFigName,"_",figNameCase,"_",planes(iPlane),"plane_ALL",".fig"); 
+            else
+                sgtitle(sprintf("plane: %s - %s - %s \n cyProg: %s - cyCode: %s",planes(iPlane),myLabels(iDataAcq),myTit,tmpCyProgs(iExtr),tmpCyCodes(iExtr)));
+                myFigSave=strcat(myFigPath,"/",myFigName,"_",figNameCase,"_",planes(iPlane),"plane_cyProg",tmpCyProgs(iExtr),"_cyCode",tmpCyCodes(iExtr),".fig"); 
+            end
+            if (exist("myFigPath","var"))
+                fprintf("...saving to file %s ...\n",myFigSave);
+                savefig(myFigSave);
+            end
+        end
+        % for summary plot
+        if (lConcatenate)
+            statLabels(iExtr)=sprintf("cyProgs: [%s:%s] - cyCodes: [%s:%s]",...
+                tmpCyProgs(1),tmpCyProgs(end),tmpCyCodes(1),tmpCyCodes(end));
+        else
+            statLabels(iExtr)=sprintf("cyProg: %s - cyCode: %s",tmpCyProgs(iExtr),tmpCyCodes(iExtr));
+        end
+    end
+    % - evolution of statistics
+    if (nExtr==1)
+        mySumTitle=strcat(myTit," - ",myLabels(iDataAcq)," - ",statLabels);
+        mySumLabs=missing();
+    else
+        mySumTitle=strcat(myTit," - ",myLabels(iDataAcq));
+        mySumLabs=statLabels;
+    end
+    if (exist("myFigPath","var"))
+        myFigSave=strcat(myFigPath,"/",myFigName,"_",figNameCase,"_stats_ALL.fig"); 
+    else
+        myFigSave=missing();
+    end
+    ShowBeamProfilesSummaryData(BARsProf,FWHMsProf,INTsProf,missing(),tmpTimes,yLab,mySumLabs,missing(),mySumTitle,myFigSave);
+    
 end
+

--- a/DisplayDCTData.m
+++ b/DisplayDCTData.m
@@ -14,10 +14,12 @@
 
 %% include libraries
 % - include Matlab libraries
-pathToLibrary="..\externalMatLabTools";
-addpath(genpath(pathToLibrary));
-pathToLibrary=".\";
-addpath(genpath(pathToLibrary));
+if (~exist("pathToLibrary","var"))
+    pathToLibrary="..\externalMatLabTools";
+    addpath(genpath(pathToLibrary));
+    pathToLibrary=".\";
+    addpath(genpath(pathToLibrary));
+end
 
 %% settings
 clear kPath DCTpaths

--- a/DisplayLPOWerrLogData.m
+++ b/DisplayLPOWerrLogData.m
@@ -10,10 +10,12 @@
 
 %% include libraries
 % - include Matlab libraries
-pathToLibrary="..\externalMatLabTools";
-addpath(genpath(pathToLibrary));
-pathToLibrary=".\";
-addpath(genpath(pathToLibrary));
+if (~exist("pathToLibrary","var"))
+    pathToLibrary="..\externalMatLabTools";
+    addpath(genpath(pathToLibrary));
+    pathToLibrary=".\";
+    addpath(genpath(pathToLibrary));
+end
 
 %% settings
 

--- a/general/Plot2DHistograms.m
+++ b/general/Plot2DHistograms.m
@@ -20,8 +20,10 @@ function [axM,axX,axY]=Plot2DHistograms(showMe,showMe1DX,showMe1DY,xINs,yINs,xSh
     %% 2D histogram
     axM=subplot('Position', [0.10, 0.10, 0.6, 0.6]);
     if ( lHist )
+        showMe(isnan(showMe))=0.0; % histogram2 cannot handle NaNs...
         hh=histogram2('XBinEdges',xShow,'YBinEdges',yShow,...
-                      'BinCounts',showMe,'FaceColor','flat','ShowEmptyBins','on');
+                      'BinCounts',showMe,'FaceColor','flat',...
+                      'ShowEmptyBins','on','LineStyle','none');
         view(2); % starts appearing as a 2D plot
     else
         plot(showMe(:,1),showMe(:,2),"k.");

--- a/measurement_analysis/BeamProfilesAlignTimes.m
+++ b/measurement_analysis/BeamProfilesAlignTimes.m
@@ -1,0 +1,17 @@
+function timesOUT=BeamProfilesAlignTimes(timesIN)
+% BeamProfilesAlignTimes      to align time arrays of beam frames acquired
+%                               with BD devices and CAMeretta dump
+% all time arrays will have the same length, i.e. no NaNs left;
+%
+% timesIN & timesOUT: float(nMaxTime,nDataSets)
+%
+    fprintf("Aligning times...\n");
+    timesOUT=timesIN;
+    nDataSets=size(timesIN,2)-1;
+    iLongest=find(~isnan(timesIN(end,:)),1,"first");
+    for ii=1:nDataSets
+        if (ii==iLongest), continue; end
+        timesOUT(:,ii)=timesIN(:,iLongest);
+    end
+    fprintf("...done.\n");
+end

--- a/measurement_analysis/BeamProfilesConcatenateTimes.m
+++ b/measurement_analysis/BeamProfilesConcatenateTimes.m
@@ -1,0 +1,25 @@
+function [profilesOUT,timesOUT]=BeamProfilesConcatenateTimes(profilesIN,timesIN)
+    fprintf("Concatenating time profiles (as if they all belonged to one extraction)...\n");
+    nFibers=size(profilesIN,1);
+    nPlanes=size(profilesIN,3);
+    nDataSets=size(profilesIN,4);
+    nActualFrames=0;
+    profilesOUT=NaN(nFibers,1,nPlanes);
+    profilesOUT(:,1,:)=profilesIN(:,1,:,1); % copy fiber position
+    timesOUT=NaN();
+    tLast=0;
+    for iDataSet=1:nDataSets
+        nLen=find(~isnan(timesIN(:,iDataSet)),1,"last"); % length of time array
+        profilesOUT(:,nActualFrames+1+1:nActualFrames+1+nLen,:)=profilesIN(:,2:nLen+1,:,iDataSet);
+        if (iDataSet>1 && timesIN(1,iDataSet)==0.0)
+            % first time stamp of new acquisition is at 0.0: avoid having 
+            %    2 profiles at the same time stamp
+            tLast=tLast+diff(timesIN(1:2,iDataSet));
+        end
+        timesOUT(nActualFrames+1:nActualFrames+nLen)=timesIN(1:nLen,iDataSet)+tLast;
+        nActualFrames=nActualFrames+nLen;
+        tLast=timesOUT(nActualFrames);
+    end
+    timesOUT=timesOUT';
+    fprintf("...done.\n");
+end

--- a/measurement_analysis/BeamProfilesConcatenateTimes.m
+++ b/measurement_analysis/BeamProfilesConcatenateTimes.m
@@ -10,7 +10,7 @@ function [profilesOUT,timesOUT]=BeamProfilesConcatenateTimes(profilesIN,timesIN)
 %
 % output variables:
 % - profilesOUT (float(nFibers,Sum_nTimeFrames+1,nPlanes)): acquired profiles;
-% - timesIN (float(Sum_nTimeFrames)): cumulative time series;
+% - timesOUT (float(Sum_nTimeFrames)): cumulative time series;
 %
     fprintf("Concatenating time profiles (as if they all belonged to one extraction)...\n");
     nFibers=size(profilesIN,1);

--- a/measurement_analysis/BeamProfilesConcatenateTimes.m
+++ b/measurement_analysis/BeamProfilesConcatenateTimes.m
@@ -1,4 +1,17 @@
 function [profilesOUT,timesOUT]=BeamProfilesConcatenateTimes(profilesIN,timesIN)
+% BeamProfilesConcatenateTimes      to concatenate beam profiles and time arrays
+%                                     of beam frames acquired with BD devices
+%                                     and CAMeretta dump as if only one
+%                                     LONG extraction took place
+%
+% input variables:
+% - profilesIN (float(nFibers,nTimeFrames+1,nPlanes,nDataSets)): acquired profiles;
+% - timesIN (float(nTimeFrames,nDataSets)): time series (as read from files);
+%
+% output variables:
+% - profilesOUT (float(nFibers,Sum_nTimeFrames+1,nPlanes)): acquired profiles;
+% - timesIN (float(Sum_nTimeFrames)): cumulative time series;
+%
     fprintf("Concatenating time profiles (as if they all belonged to one extraction)...\n");
     nFibers=size(profilesIN,1);
     nPlanes=size(profilesIN,3);

--- a/measurement_analysis/ParseBeamProfiles.m
+++ b/measurement_analysis/ParseBeamProfiles.m
@@ -159,6 +159,7 @@ function [measData,cyCodes,cyProgs,times]=ParseBeamProfiles(paths2Files,fFormat)
                     measData(1:Ny,2:nRows+1,2,actualDataSets)=tmp(:,Nx+2:Nx+1+Ny)'; % values
                     % t-stamps
                     times(1:nRows,actualDataSets)=tmp(:,1)';
+                    times(nRows+1:end,actualDataSets)=NaN();
                 case "DDS"
                     nAcq=nAcq+1;
                     fprintf("...parsing file %d/%d: %s ...\n",iSet,nDataSets,files(iSet).name);
@@ -207,6 +208,7 @@ function [measData,cyCodes,cyProgs,times]=ParseBeamProfiles(paths2Files,fFormat)
                     tmpCyCode=extractBetween(tmpCyCode,5,strlength(tmpCyCode));
                     % t-stamps
                     times(1:nCols-1,actualDataSets)=(0:10:(nCols-2)*10)';
+                    times(nCols:end,actualDataSets)=NaN();
                 case {"PMM","PIB"}
                     if (strfind(files(iSet).name,"Norm"))
                         fprintf("   ...skipping Norm file %d/%d: %s ...\n",iSet,nDataSets,files(iSet).name);
@@ -231,6 +233,7 @@ function [measData,cyCodes,cyProgs,times]=ParseBeamProfiles(paths2Files,fFormat)
                     measData(1:Ny,1:nMaxCols,2,actualDataSets)=tmp(1:Ny,1+2:2+nMaxCols); % values
                     % t-stamps
                     times(1:nCols-1,actualDataSets)=(0:10:(nCols-2)*10)';
+                    times(nCols:end,actualDataSets)=NaN();
                 case {"QBM","QPP","SFH","SFM","SFP"}
                     nAcq=nAcq+1;
                     fprintf("...parsing file %d/%d: %s ...\n",iSet,nDataSets,files(iSet).name);
@@ -257,6 +260,7 @@ function [measData,cyCodes,cyProgs,times]=ParseBeamProfiles(paths2Files,fFormat)
                     end
                     % t-stamps
                     times(1:nCols-1,actualDataSets)=(0:10:(nCols-2)*10)';
+                    times(nCols:end,actualDataSets)=NaN();
             end
             % store cycle prog and cycle code
             cyProgs(actualDataSets)=tmpCyProg;

--- a/measurement_analysis/PlotSinogram.m
+++ b/measurement_analysis/PlotSinogram.m
@@ -1,11 +1,15 @@
-function PlotSinogram(xs,ys,data,l3D)
+function PlotSinogram(xs,ys,data,l3D,iNotShow)
 % input variables:
 % - xs, ys: bin centres (1D float);
 % - data: 2D (color) map (2D float);
 %         . data vs X: cols;
 %         . data vs Y: rows;
 % - l3D: boolean requesting a 3D plot (top view by default);
+% - iNotShow: do not show specific rows or columns:
+%   . (array of booleans): length(iNotShow)=length(xs);
+%   . (array of integers): length(iNotShow)<=length(xs);
     if (~exist("l3D","var")), l3D=true; end
+    if (~exist("iNotShow","var")), iNotShow=missing(); end
     [xT,idx]=sort(xs);
     [yT,idy]=sort(ys);
     if (l3D)
@@ -17,8 +21,13 @@ function PlotSinogram(xs,ys,data,l3D)
         showMe=data';
         showMe=showMe(idx,:);
         showMe=showMe(:,idy);
+        showMe(isnan(showMe))=0.0; % histogram2 cannot handle NaNs...
+        if (any(~ismissing(iNotShow)))
+            showMe(:,iNotShow)=0.0;
+        end
         histogram2('XBinEdges',xShow,'YBinEdges',yShow,...
-                   'BinCounts',showMe,'FaceColor','flat','ShowEmptyBins','on');
+                   'BinCounts',showMe,'FaceColor','flat',...
+                   'ShowEmptyBins','on','LineStyle','none');
         view(2); % starts appearing as a 2D plot
     else
         % 2D plot via imagesc:
@@ -27,6 +36,9 @@ function PlotSinogram(xs,ys,data,l3D)
         showMe=data;
         showMe=showMe(:,idx);
         showMe=showMe(idy,:);
+        if (any(~ismissing(iNotShow)))
+            showMe(iNotShow,:)=0.0;
+        end
         imagesc('XData',xT,'YData',yT,'CData',showMe);
         colorbar;
     end

--- a/measurement_analysis/PlotSpectra.m
+++ b/measurement_analysis/PlotSpectra.m
@@ -1,4 +1,4 @@
-function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod)
+function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod,iNotShow)
 % PlotSpectra     plots distributions/histograms in a 3D space with a free parameter;
 %                 this plotting function can be useful to explore eg
 %                   spectra taken during scans;
@@ -19,6 +19,9 @@ function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod)
 %   . 1: colored histograms in a 3D view;
 %   . 2: sinogram-like view;
 %   . 3: 3D sinogram-like;
+% - iNotShow: do not show specific rows or columns:
+%   . (array of booleans): length(iNotShow)=length(xs);
+%   . (array of integers): length(iNotShow)<=length(xs);
 %
 % see also ParseSFMData, ShowSpectra and SumSpectra.
 %
@@ -29,6 +32,7 @@ function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod)
     if ( ~exist('addIndex','var') | all(ismissing(addIndex)) ), addIndex=1:nDataSets; end
     if ( ~exist('addLabel','var') | all(ismissing(addLabel)) ), addLabel="ID"; end
     if ( ~exist('iMod','var') | ismissing(iMod) ), iMod=1; end
+    if (~exist("iNotShow","var")), iNotShow=missing(); end
 
     %% actually plot
     switch iMod
@@ -41,18 +45,18 @@ function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod)
             end
             for iSet=1:nDataSets
                 if (iSet>1), hold on; end
-                PlotSpectrum(dataSets(:,1),dataSets(:,1+iSet),addIndex(iSet),cm(iSet,:));
+                PlotSpectrum(dataSets(:,1),dataSets(:,1+iSet),addIndex(iSet),cm(iSet,:),iNotShow);
             end
             ylabel(LabelMe(addLabel));
         case 2
             % sinogram-like view
             l3D=false;
-            PlotSinogram(addIndex,dataSets(:,1),dataSets(:,2:end),l3D);
+            PlotSinogram(addIndex,dataSets(:,1),dataSets(:,2:end),l3D,iNotShow);
             xlabel(LabelMe(addLabel));
         case 3
             % 3D sinogram-like
             l3D=true;
-            PlotSinogram(addIndex,dataSets(:,1),dataSets(:,2:end),l3D);
+            PlotSinogram(addIndex,dataSets(:,1),dataSets(:,2:end),l3D,iNotShow);
             xlabel(LabelMe(addLabel));
         otherwise
             error("Wrong mode! %d",iMod);
@@ -60,7 +64,7 @@ function PlotSpectra(dataSets,BaW,addIndex,addLabel,iMod)
     grid on;
 end
 
-function PlotSpectrum(xx,yy,iSet,color)
+function PlotSpectrum(xx,yy,iSet,color,iNotShow)
 % PlotSpectrum      function actually plotting a single distribution
 %                   the distribution is plotted as a colored histogram in a 3D
 %                   space, where the axes are:
@@ -74,14 +78,16 @@ function PlotSpectrum(xx,yy,iSet,color)
 %   NB: xx and yy must be row vectors, not column vectors!
 % - iSet [integer]: index of the current data set (will be used as Y-coordinate);
 % - color [float(3)]: RGB codification of color;
+% - iNotShow: do not show specific rows or columns:
+%   . (array of booleans): length(iNotShow)=length(xs);
+%   . (array of integers): length(iNotShow)<=length(xs);
 %
-    plotX=xx;
-    if ( size(plotX,2)== 1 )
-        plotX=plotX';
-    end
-    plotY=yy;
-    if ( size(plotY,2)== 1 )
-        plotY=plotY';
+    if (~exist("iNotShow","var")), iNotShow=missing(); end
+    plotX=xx; plotY=yy;
+    if ( size(plotX,2)== 1 ), plotX=plotX'; end
+    if ( size(plotY,2)== 1 ), plotY=plotY'; end
+    if (any(~ismissing(iNotShow)))
+        plotY(iNotShow)=0.0;
     end
     % get non-zero values
     indices=(plotY~=0.0);

--- a/measurement_analysis/ShowBeamProfilesSummaryData.m
+++ b/measurement_analysis/ShowBeamProfilesSummaryData.m
@@ -51,12 +51,12 @@ function ShowBeamProfilesSummaryData(BARs,SIGs,INTs,ASYMs,xVals,xLab,labels,what
     end
     
     % actually generate figure
-    cm=colormap(turbo(nSets));
     if (~ismissing(myTitle))
         ff=figure("Name",LabelMe(myTitle));
     else
         ff=figure();
     end
+    cm=colormap(ff,turbo(nSets));
     iPlot=0;
     if ( nSets==2 )
         markers=[ "o" "*" ];

--- a/measurement_analysis/ShowSpectra.m
+++ b/measurement_analysis/ShowSpectra.m
@@ -1,4 +1,4 @@
-function ShowSpectra(dataSets,tmpTitleFig,addIndex,addLabel,myLabels,myFigSave,iMod)
+function ShowSpectra(dataSets,tmpTitleFig,addIndex,addLabel,myLabels,myFigSave,iMod,iNotShow)
 % ShowSpectra     shows distributions recorded by SFM, QBM and GIM;
 %                 it shows a 1x2 3D figure, with the distributions on the
 %                   horizontal plane on the left and those on the vertical
@@ -25,24 +25,29 @@ function ShowSpectra(dataSets,tmpTitleFig,addIndex,addLabel,myLabels,myFigSave,i
 %   . 1: colored histograms in a 3D view;
 %   . 2: sinogram-like view;
 %   . 3: 3D sinogram-like;
+% - iNotShow: do not show specific rows or columns:
+%   . (array of booleans): length(iNotShow)=length(xs);
+%   . (array of integers): length(iNotShow)<=length(xs);
 %
 % see also ParseSFMData, PlotSpectra and SumSpectra.
 
     fprintf("plotting data...\n");
 
     %% pre-processing
+    nDataSets=size(dataSets,4);
+    planes=["horizontal plane" "vertical plane"];
+    nPlanes=length(planes);
+    
     if (~exist("addIndex","var") | all(ismissing(addIndex))), addIndex=missing(); end
     if (~exist("addLabel","var") | all(ismissing(addLabel))), addLabel=missing(); end
     if (~exist("myLabels","var") | all(ismissing(addLabel))), myLabels=missing(); end
     if (~exist("myFigSave","var")), myFigSave=missing(); end
     if (~exist('iMod','var') | ismissing(iMod)), iMod=1; end
+    if (~exist("iNotShow","var")), iNotShow=NaN(1,nPlanes); end
     
     %% actually plotting
     ff=figure('Name',LabelMe(tmpTitleFig),'NumberTitle','off');
     BaW=false; % always use colored plots
-    nDataSets=size(dataSets,4);
-    planes=["horizontal plane" "vertical plane"];
-    nPlanes=length(planes);
     [nRows,nCols,lDispHor]=GetNrowsNcols(nPlanes*nDataSets,nPlanes);
     
     if (lDispHor)
@@ -64,9 +69,9 @@ function ShowSpectra(dataSets,tmpTitleFig,addIndex,addLabel,myLabels,myFigSave,i
                 subplot(nRows,nCols,jPlot);
             end
             if ( ismissing(addIndex) & ismissing(addLabel) )
-                PlotSpectra(dataSets(:,:,iPlane,iDataSet),BaW,missing(),missing(),iMod);
+                PlotSpectra(dataSets(:,:,iPlane,iDataSet),BaW,missing(),missing(),iMod,iNotShow(:,iPlane));
             else
-                PlotSpectra(dataSets(:,:,iPlane,iDataSet),BaW,addIndex(:,iDataSet),addLabel,iMod);
+                PlotSpectra(dataSets(:,:,iPlane,iDataSet),BaW,addIndex(:,iDataSet),addLabel,iMod,iNotShow(:,iPlane));
             end
             if (ismissing(myLabels))
                 title(planes(iPlane));

--- a/measurement_analysis/SumSpectra.m
+++ b/measurement_analysis/SumSpectra.m
@@ -1,30 +1,58 @@
-function sumData=SumSpectra(data)
-% SumSpectra     computes the distribution sum of those recorded by SFM, QBM and GIM;
+function sumData=SumSpectra(data,times)
+% SumSpectra     computes either the distribution sum of those recorded by SFM, QBM and GIM,
+%                   or the evolution of the integral (times var provided or ~=missing());
 %
 % input:
 % - data [float(max(Nx,Ny),maxColumns,2,nDataSets)]: array of data. See ParseSFMData
 %   for further info on formats;
+% - times [float(maxColumns-1,nDataSets)] (optional): time stamps of frames;
+%   if this var is provided, the evolution of the integral is computed instead
+%      of the distribution sum;
 % 
 % output:
-% - sumData [float(Nn,nDataSets+1,2)]: array of data;
+% - sumData: array of data; its actual dimensions depend on the sum requested,
+%   i.e. if times is provided or not:
+%     times not provided or ==missing() (distribution sum, default):
+%           [float(Nn,nDataSets+1,2)]
+%     times provided and ~=missing() (evolution with time of integral):
+%           [float(Ntimes,nDataSets+1,2)]: 
+%   where:
 %   . Nn: number of fibers;
-%   . nDataSets: number of files; the second dimension of the array
-%     also contains the values of x/y in the first column;
+%   . nDataSets: number of files;
+%   . Ntimes: number of time stamps;
 %   . 2: planes: 1: hor; 2: ver;
+%
+%   Please keep in mind that the second dimension of the array lists in the 
+%     first column either the x/y central positions of the fibers/channels
+%     (distribution sum, default) or the time stamps of frames;
 %
 % see also ParseSFMData and IntegrateSpectra.
 
-    fprintf("computing sums...\n");
+    if (~exist("times","var")), times=missing(); end
     Nn=size(data,1);
     nDataSets=size(data,4);
-    sumData=zeros(Nn,nDataSets+1,2);
     
-    sumData(:,1,:)=data(:,1,:,1); % copy positions of fibers on both planes from first data set
-    for iSet=1:nDataSets
-        % get total distribution for each data set
-        sumData(:,iSet+1,:)=sum(data(:,2:end,:,iSet),2,'omitnan');
+    fprintf("computing sums...\n");
+    if (size(times,1)==1 && size(times,2)==1)
+        sumData=zeros(Nn,nDataSets+1,2);
+        sumData(:,1,:)=data(:,1,:,1); % copy positions of fibers on both planes from first data set
+        for iSet=1:nDataSets
+            % get total distribution for each data set
+            sumData(:,iSet+1,:)=sum(data(:,2:end,:,iSet),2,'omitnan');
+        end
+    else
+        if (nDataSets~=size(times,2))
+            error("Inconsistent number of DataSets: %d (profiles) vs %d (timestamps)",...
+                nDataSets,size(times,2));
+        end
+        nTimes=size(times,1);
+        sumData=zeros(nTimes,nDataSets+1,2);
+        % copy positions of fibers on both planes from first data set
+        sumData(:,1,1)=times(:,1); % hor plane
+        sumData(:,1,2)=times(:,1); % ver plane
+        for iSet=1:nDataSets
+            % get integral for each time frame
+            sumData(:,iSet+1,:)=sum(data(:,2:end,:,iSet),1,'omitnan');
+        end
     end
 end
-
-
-

--- a/measurement_analysis/SumSpectra.m
+++ b/measurement_analysis/SumSpectra.m
@@ -34,6 +34,7 @@ function sumData=SumSpectra(data,times)
     
     fprintf("computing sums...\n");
     if (size(times,1)==1 && size(times,2)==1)
+        sprintf("...getting sum profiles...\n");
         sumData=zeros(Nn,nDataSets+1,2);
         sumData(:,1,:)=data(:,1,:,1); % copy positions of fibers on both planes from first data set
         for iSet=1:nDataSets
@@ -41,13 +42,14 @@ function sumData=SumSpectra(data,times)
             sumData(:,iSet+1,:)=sum(data(:,2:end,:,iSet),2,'omitnan');
         end
     else
+        sprintf("...getting time evolution...\n");
         if (nDataSets~=size(times,2))
             error("Inconsistent number of DataSets: %d (profiles) vs %d (timestamps)",...
                 nDataSets,size(times,2));
         end
         nTimes=size(times,1);
         sumData=zeros(nTimes,nDataSets+1,2);
-        % copy positions of fibers on both planes from first data set
+        % copy time values on both planes
         sumData(:,1,1)=times(:,1); % hor plane
         sumData(:,1,2)=times(:,1); % ver plane
         for iSet=1:nDataSets
@@ -55,4 +57,5 @@ function sumData=SumSpectra(data,times)
             sumData(:,iSet+1,:)=sum(data(:,2:end,:,iSet),1,'omitnan');
         end
     end
+    fprintf("...done.\n");
 end


### PR DESCRIPTION
Added a script to show time profiles acquired with the CAMeretta dumps (parsing of files with raw data included).
The time profiles are visualised as a 2D histogram, with the spatial coordinate as x-axis and time as y-axis. It is possible to align the time scale of each acquisition or concatenate them one after the other, as if only one LONG extraction took place.

At the same time:
* it is possible to compute not only the total beam distribution as integral of the series of time frames, but also the time evolution of the beam intensity;
* `DisplayBeamProfiles.m` shows profiles (integrated along the extraction time) from CAMeretta dumps as it is done for other BD systems;
* addition of search paths only in case `pathToLibrary` var does not exist in all main scripts;
* removing black lines surrounding colormap tiles when plotting 2D histograms;
* added a protection against NaNs when plotting 2D histograms;
* added possibility to set to 0.0 (for all acquisitions) channels giving spurious readouts when plotting beam profiles;
* bug fix in figure handling when colormap is issued when plotting beam profiles;